### PR TITLE
Ls/up 9.0

### DIFF
--- a/benchmark/FasterKvCache.Benchmark/FasterKvCache.Benchmark.csproj
+++ b/benchmark/FasterKvCache.Benchmark/FasterKvCache.Benchmark.csproj
@@ -2,14 +2,14 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/benchmark/FasterKvCache.Benchmark/Program.cs
+++ b/benchmark/FasterKvCache.Benchmark/Program.cs
@@ -17,7 +17,7 @@ public enum TestType
 
 [GcForce]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
-[SimpleJob(RuntimeMoniker.Net60, launchCount: 1, warmupCount: 5, targetCount: 10)]
+[SimpleJob(RuntimeMoniker.Net60, launchCount: 1, warmupCount: 5, iterationCount: 10)]
 [MemoryDiagnoser]
 #nullable disable
 public class FasterKvBenchmark

--- a/src/FasterKv.Cache.Core/FasterKv.Cache.Core.csproj
+++ b/src/FasterKv.Cache.Core/FasterKv.Cache.Core.csproj
@@ -1,12 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.FASTER.Core" Version="2.1.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
+      <PackageReference Include="Microsoft.FASTER.Core" Version="2.6.5" />
+      <PackageReference Update="PolySharp" Version="1.15.0" />
     </ItemGroup>
 
 </Project>

--- a/src/FasterKv.Cache.MessagePack/FasterKv.Cache.MessagePack.csproj
+++ b/src/FasterKv.Cache.MessagePack/FasterKv.Cache.MessagePack.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MessagePack" Version="2.4.59" />
+      <PackageReference Include="MessagePack" Version="3.1.3" />
     </ItemGroup>
 
 </Project>

--- a/src/FasterKv.Cache.SystemTextJson/FasterKv.Cache.SystemTextJson.csproj
+++ b/src/FasterKv.Cache.SystemTextJson/FasterKv.Cache.SystemTextJson.csproj
@@ -5,7 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Text.Json" Version="7.0.0" />
+      <PackageReference Include="System.Text.Json" Version="9.0.3" />
+      <PackageReference Update="PolySharp" Version="1.15.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/FasterKv.Cache.Core.Tests/FasterKv.Cache.Core.Tests.csproj
+++ b/tests/FasterKv.Cache.Core.Tests/FasterKv.Cache.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -11,13 +11,13 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
This pull request includes several updates to target frameworks and package versions across multiple project files to ensure compatibility with newer versions of dependencies and frameworks.

### Target Framework Updates:
* [`benchmark/FasterKvCache.Benchmark/FasterKvCache.Benchmark.csproj`](diffhunk://#diff-675d5570b7bd6de2c76582e12b273bd9383979f7b0c53bbddec74f01ba50d320L5-R12): Updated target framework from `net6.0` to `net9.0`.
* [`src/FasterKv.Cache.Core/FasterKv.Cache.Core.csproj`](diffhunk://#diff-a4065f426dd79cd9e20b8ddb28ab851f97290d2560fce45cb758353e5b891681L4-R11): Added `net8.0` and `net9.0` to the target frameworks.
* [`tests/FasterKv.Cache.Core.Tests/FasterKv.Cache.Core.Tests.csproj`](diffhunk://#diff-9cbfd32a63ebf14f8e6a4076164ff32acd01acaa9c2370536329b9f8cbcc5b42L4-R4): Updated target framework from `net7.0` to `net9.0`.

### Package Version Updates:
* [`benchmark/FasterKvCache.Benchmark/FasterKvCache.Benchmark.csproj`](diffhunk://#diff-675d5570b7bd6de2c76582e12b273bd9383979f7b0c53bbddec74f01ba50d320L5-R12): Updated `BenchmarkDotNet` to version `0.14.0` and `Microsoft.Extensions.DependencyInjection.Abstractions` to version `9.0.3`.
* [`src/FasterKv.Cache.Core/FasterKv.Cache.Core.csproj`](diffhunk://#diff-a4065f426dd79cd9e20b8ddb28ab851f97290d2560fce45cb758353e5b891681L4-R11): Updated `Microsoft.FASTER.Core` to version `2.6.5` and added `PolySharp` version `1.15.0`.
* [`src/FasterKv.Cache.MessagePack/FasterKv.Cache.MessagePack.csproj`](diffhunk://#diff-a26f3de384e28ded54905c3033487fd147ed0c38927694696545703b134700c6L12-R12): Updated `MessagePack` to version `3.1.3`.
* [`src/FasterKv.Cache.SystemTextJson/FasterKv.Cache.SystemTextJson.csproj`](diffhunk://#diff-4b385af05e3db75f60edb767bb5766033b5a59488aabbe409cf773b4cd37f561L8-R9): Updated `System.Text.Json` to version `9.0.3` and added `PolySharp` version `1.15.0`.
* [`tests/FasterKv.Cache.Core.Tests/FasterKv.Cache.Core.Tests.csproj`](diffhunk://#diff-9cbfd32a63ebf14f8e6a4076164ff32acd01acaa9c2370536329b9f8cbcc5b42L14-R20): Updated `Moq` to version `4.20.72`, `xunit` to version `2.9.3`, `xunit.runner.visualstudio` to version `3.0.2`, and `coverlet.collector` to version `6.0.4`.

### Benchmark Configuration Change:
* [`benchmark/FasterKvCache.Benchmark/Program.cs`](diffhunk://#diff-a8cb61d8b83ad6fdd601a7887ee0040dbcb08cced10ad4a62c1e044767f6059cL20-R20): Changed `SimpleJob` attribute from `targetCount` to `iterationCount`.